### PR TITLE
Fix typo in entrypoint script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ echo "Generating cron schedules"
 echo "${BARMAN_CRON_SCHEDULE} barman /usr/local/bin/barman receive-wal --create-slot ${DB_HOST}; /usr/local/bin/barman cron" >> /etc/cron.d/barman
 echo "${BARMAN_BACKUP_SCHEDULE} barman /usr/local/bin/barman backup all" >> /etc/cron.d/barman
 
-cho "Generating Barman configurations"
+echo "Generating Barman configurations"
 cat /etc/barman.conf.template | envsubst > /etc/barman.conf
 cat /etc/barman/barman.d/pg.conf.template | envsubst > /etc/barman/barman.d/${DB_HOST}.conf
 echo "${DB_HOST}:${DB_PORT}:*:${DB_SUPERUSER}:${DB_SUPERUSER_PASSWORD}" > /home/barman/.pgpass


### PR DESCRIPTION
I saw this error fly by while looking at CI when building a [Helm chart using this image](https://github.com/adfinis-sygroup/helm-charts/tree/master/charts/barman).