### PR TITLE
fix: update path to tini `init`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,4 +87,4 @@ WORKDIR ${BARMAN_DATA_DIR}
 # the CMD which, by default, starts cron.  The 'barman -q cron' job will get
 # pg_receivexlog running.  Cron may also have jobs installed to run
 # 'barman backup' periodically.
-ENTRYPOINT ["/tini", "--", "/entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/entrypoint.sh"]


### PR DESCRIPTION
Hi, me again. You seem to have missed updating the entrypoint while switching to the distro provided tini binary.

Thanks