### PR TITLE
Add postgres clients 16 and 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN bash -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg ma
 		postgresql-client-13 \
 		postgresql-client-14 \
 		postgresql-client-15 \
+  		postgresql-client-16 \
+    		postgresql-client-17 \
 		python3 \
         python3-distutils \
 		rsync \


### PR DESCRIPTION
Since last update new postgres versions popped up. This will prolong the life of the repo.